### PR TITLE
Bean init error solved

### DIFF
--- a/Online-Accommodation-System/pom.xml
+++ b/Online-Accommodation-System/pom.xml
@@ -8,6 +8,9 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Online-Accommodation-System Maven Webapp</name>
 	<url>http://maven.apache.org</url>
+	<properties>
+		<slf4jVersion>1.6.1</slf4jVersion>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -86,16 +89,37 @@
 			<version>2.10.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.jadira.usertype/usertype.core -->
-		<dependency>
+<!-- 		<dependency>
 			<groupId>org.jadira.usertype</groupId>
 			<artifactId>usertype.core</artifactId>
 			<version>3.2.0.GA</version>
 		</dependency>
-		<dependency>
+ -->		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>8.0.11</version>
 		</dependency>
+
+		<!-- Logging Dependencies -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4jVersion}</version>
+		</dependency>
+		<!-- Binding for System.out -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4jVersion}</version>
+		</dependency>
+		<!--Binding for log4j version 1.2.x You also need to place log4j.jar on 
+			your class path. -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${slf4jVersion}</version>
+		</dependency>
+		<!-- ============================================ -->
 	</dependencies>
 	<build>
 		<finalName>Online-Accommodation-System</finalName>

--- a/Online-Accommodation-System/src/main/resources/log4j.properties
+++ b/Online-Accommodation-System/src/main/resources/log4j.properties
@@ -1,0 +1,13 @@
+jdbc.driverClassName=com.mysql.cj.jdbc.Driver
+jdbc.dialect=org.hibernate.dialect.MySQL5Dialect
+jdbc.databaseurl=jdbc:mysql://localhost:3306/Ostendb
+jdbc.username=root
+jdbc.password=prerna
+
+hibernate.temp.use_jdbc_metadata_defaults= false
+hibernate.dialect = org.hibernate.dialect.MySQL5Dialect
+hibernate.show_sql = true
+hibernate.format_sql = true
+hibernate.hbm2ddl.auto = update
+
+#These configurations depends on your setup


### PR DESCRIPTION
1. Bean init error resolved by removing unused jadira.sertype jar. This jar is incompatible with hibernate5. Use ver > 6 in case required.
2. Added log4j.properties for detailed message printing.